### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.1'
+        kotlinCompilerExtensionVersion '1.5.0'
     }
     packagingOptions {
         resources {
@@ -50,14 +50,14 @@ dependencies {
 
     implementation project(':colorpicker')
 
-    implementation 'com.github.SmartToolFactory:Compose-Colorful-Sliders:1.1.0'
-    implementation 'com.github.SmartToolFactory:Compose-Extended-Gestures:2.1.0'
+    implementation 'com.github.SmartToolFactory:Compose-Colorful-Sliders:1.2.0'
+    implementation 'com.github.SmartToolFactory:Compose-Extended-Gestures:3.0.0'
     implementation 'com.github.SmartToolFactory:Compose-Extended-Colors:1.0.0-alpha07'
 
     // Jetpack Compose
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
 
     // Jetpack Compose
     implementation "androidx.compose.ui:ui:$compose_version"
@@ -65,15 +65,15 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
 
 
-    def accompanist_version = "0.25.0"
+    def accompanist_version = "0.30.1"
     // Accompanist
     implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-drawablepainter:$accompanist_version"
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
     ext {
-        compose_version = '1.3.0-beta02'
+        compose_version = '1.4.3'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
 }
 
 task clean(type: Delete) {

--- a/colorpicker/build.gradle
+++ b/colorpicker/build.gradle
@@ -31,7 +31,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.1'
+        kotlinCompilerExtensionVersion '1.5.0'
     }
 
     packagingOptions {
@@ -44,24 +44,24 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.10.1'
 
-    implementation 'com.github.SmartToolFactory:Compose-Extended-Gestures:2.1.0'
+    implementation 'com.github.SmartToolFactory:Compose-Extended-Gestures:3.0.0'
     implementation 'com.github.SmartToolFactory:Compose-Extended-Colors:1.0.0-alpha07'
     implementation 'com.github.SmartToolFactory:Compose-Screenshot:1.0.3'
     implementation 'com.github.SmartToolFactory:Compose-Color-Detector:1.0.0'
-    implementation 'com.github.SmartToolFactory:Compose-Colorful-Sliders:1.1.0'
+    implementation 'com.github.SmartToolFactory:Compose-Colorful-Sliders:1.2.0'
     // Jetpack Compose
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.runtime:runtime:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.material3:material3:1.0.0-beta02"
+    implementation "androidx.compose.material3:material3:1.1.1"
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 09 09:44:35 TRT 2022
+#Tue Jul 25 14:46:27 AEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Update dependencies to support and make it compatible with latest Jetpack Compose.

Also, furthermore, that fixes the following issue:
`java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/compose/material/TouchTargetKt`